### PR TITLE
Document npm audit 403 failure in SECURITY-CHECK.md

### DIFF
--- a/SECURITY-CHECK.md
+++ b/SECURITY-CHECK.md
@@ -1,0 +1,11 @@
+# Security Check
+
+## npm audit
+
+Attempted `npm audit --audit-level=low`, but the registry endpoint returned a 403 Forbidden error in this environment, so a vulnerability report could not be generated.
+
+```
+npm warn audit 403 Forbidden - POST https://registry.npmjs.org/-/npm/v1/security/advisories/bulk
+Forbidden
+npm error audit endpoint returned an error
+```


### PR DESCRIPTION
### Motivation
- Document the unsuccessful attempt to run `npm audit --audit-level=low` and capture the registry `403 Forbidden` response for future triage.

### Description
- Add `SECURITY-CHECK.md` with a short note recording the attempted `npm audit` command and the exact error output returned by the registry.

### Testing
- Ran `npm audit --audit-level=low`, which failed with a `403 Forbidden` error from the npm registry and is recorded in `SECURITY-CHECK.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69816fe4c6a483218f09889344a69a77)